### PR TITLE
Remove recursive nature of three_lines.py

### DIFF
--- a/three_lines.py
+++ b/three_lines.py
@@ -21,6 +21,6 @@ memory = {'clear': lambda: (os.system("cls")),
           'print': lambda mem: (field := mem['field'][0],
                                 print("\n".join(["".join('#' if j == 1 else ' ' for j in i) for i in field]))),
           'run_generations': lambda mem: (mem['clear'](), mem['print'](mem), time.sleep(1), mem['update'](mem), mem['run_generations'](mem)),
-          'start': lambda mem: (mem['init'](mem), mem['run_generations'](mem)),
+          'start': lambda mem: (mem['init'](mem), (lambda mem: [mem['run_generations'](mem) for _ in iter(int, 1)])(mem)),
           'field': []}
 memory['start'](memory)


### PR DESCRIPTION
- Remove recursiveness with an infinite list comprehension by abusing the `iter` function with a never ending, ending condition.

Note
----
I don't have the brain capability right now to update the 2 line code with this line:
*  `'start': lambda mem: (mem['init'](mem), (lambda mem: [mem['run_generations'](mem) for _ in iter(int, 1)])(mem)),`
>> may someone else come and peek up this work. 

@NadavHR == js_enjoyer.
-- True -- 